### PR TITLE
Select second handle with right click

### DIFF
--- a/RangeSlider/RangeSlider.py
+++ b/RangeSlider/RangeSlider.py
@@ -23,7 +23,7 @@ class RangeSliderH(Frame):
                     auto=True, line_width=3, bar_radius=10,
                     bar_color_inner='#5c8a8a', line_s_color="#0a50ff", bar_color_outer='#c2d6d6', line_color = '#476b6b', bgColor= '#ffffff', step_marker_color = "#ffffff", font_color = '#000000',
                     show_value = True, digit_precision='.1f', valueSide='TOP', font_family='Times', font_size=16, suffix="",
-                    step_size = 0,step_marker=False, cross_each_other = False):
+                    step_size = 0,step_marker=False, cross_each_other = False, enable_right_click_movement=False):
         RangeSliderH.LINE_COLOR=line_color
         RangeSliderH.LINE_WIDTH=line_width
         RangeSliderH.BAR_COLOR_INNER=bar_color_inner
@@ -129,16 +129,18 @@ class RangeSliderH(Frame):
 
         self.canv = Canvas(self, height = self.canv_H, width = self.canv_W, bg=bgColor, bd=0 , highlightthickness=0, relief='ridge')
         self.canv.pack()
-        # now able to grab right handle with right click if two handles are on the same position
-        # other possibilities without right-click: 
-        # - move handle in direction of click on track; 
-        # - if bars have equal position on mousedown, select based on first movement 
-        # - if bars are both at 0, select second/right handle
-        self.canv.bind("<Button-1>", self._mouseMotion_b1)
-        self.canv.bind("<Button-3>", self._mouseMotion_b3)
+
         self.canv.bind("<Motion>", self._mouseMotion_b1)  # still leave the selection on motion without click / after mouse was released
         self.canv.bind("<B1-Motion>", self._moveBar)
-        self.canv.bind("<B3-Motion>", self._moveBar)
+        if enable_right_click_movement:
+            # now able to grab right handle with right click if two handles are on the same position
+            # other possibilities without right-click: 
+            # - move handle in direction of click on track; 
+            # - if bars have equal position on mousedown, select based on first movement 
+            # - if bars are both at 0, select second/right handle
+            # self.canv.bind("<Button-1>", self._mouseMotion_b1)  # not necessary
+            self.canv.bind("<Button-3>", self._mouseMotion_b3)
+            self.canv.bind("<B3-Motion>", self._moveBar)
 
         self.track = self.__addTrack(self.slider_x, self.slider_y, self.canv_W-self.slider_x, self.slider_y, self.bars[0]["Pos"], self.bars[1]["Pos"])
         tempIdx=0

--- a/RangeSlider/RangeSlider.py
+++ b/RangeSlider/RangeSlider.py
@@ -129,8 +129,13 @@ class RangeSliderH(Frame):
 
         self.canv = Canvas(self, height = self.canv_H, width = self.canv_W, bg=bgColor, bd=0 , highlightthickness=0, relief='ridge')
         self.canv.pack()
-        self.canv.bind("<Motion>", self._mouseMotion)
+        # now able to grab right handle with right click if two handles are on the same position
+        # other possibilities without right-click: move handle in direction of click on track; if bars have equal position on mousedown, select based on first movement 
+        self.canv.bind("<Button-1>", self._mouseMotion_b1)
+        self.canv.bind("<Button-3>", self._mouseMotion_b3)
+        self.canv.bind("<Motion>", self._mouseMotion_b1)  # still leave the selection on motion without click / after mouse was released
         self.canv.bind("<B1-Motion>", self._moveBar)
+        self.canv.bind("<B3-Motion>", self._moveBar)
 
         self.track = self.__addTrack(self.slider_x, self.slider_y, self.canv_W-self.slider_x, self.slider_y, self.bars[0]["Pos"], self.bars[1]["Pos"])
         tempIdx=0
@@ -174,7 +179,7 @@ class RangeSliderH(Frame):
         for idx in range(len(self.bars)):
             self.__moveBar(idx, pos[idx])
 
-    def _mouseMotion(self, event):
+    def _mouseMotion_b1(self, event):
         x = event.x; y = event.y
         selection = self.__checkSelection(x,y)
         if selection[0]:
@@ -183,6 +188,17 @@ class RangeSliderH(Frame):
         else:
             self.canv.config(cursor = "")
             self.selected_idx = None
+
+    def _mouseMotion_b3(self, event):
+        x = event.x; y = event.y
+        selection = self.__checkSelection(x,y, right_handle_first=True)
+        if selection[0]:
+            self.canv.config(cursor = "hand2")
+            self.selected_idx = selection[1]
+        else:
+            self.canv.config(cursor = "")
+            self.selected_idx = None
+
 
     def _moveBar(self, event):
         x = event.x; y = event.y
@@ -292,15 +308,18 @@ class RangeSliderH(Frame):
             otherPos=positions[1]
             if self.cross_each_other == False:
                 if pos<=otherPos:
+                # if pos<otherPos:  # test pw
                     pos=pos
                 else:
                     pos=current_pos
+                    # self.selected_idx = otherIdx  # test pw, select the second handle 
             self.track[0], self.track[1], self.track[-1] = self.__addTrackL(self.slider_x, self.slider_y, self.canv_W-self.slider_x, self.slider_y, pos, otherPos)
         else:
             otherIdx=0
             otherPos=positions[0]
             if self.cross_each_other == False:
                 if pos>=otherPos:
+                # if pos>otherPos:  # test pw not allowing same values can sometimes be useful
                     pos=pos
                 else:
                     pos=current_pos
@@ -337,16 +356,22 @@ class RangeSliderH(Frame):
         pos = self.__calcPos(x)
         return pos*(self.max_val - self.min_val)+self.min_val
 
-    def __checkSelection(self, x, y):
+    def __checkSelection(self, x, y, right_handle_first=False):
         """
         To check if the position is inside the bounding rectangle of a Bar
         Return [True, bar_index] or [False, None]
         """
-        for idx in range(len(self.bars)):
+        if right_handle_first:
+            bars_ids = reversed(range(len(self.bars)))
+        else:
+            bars_ids = range(len(self.bars))
+
+        for idx in bars_ids:
             id = self.bars[idx]["Ids"][0]
             bbox = self.canv.bbox(id)
             if bbox[0] < x and bbox[2] > x and bbox[1] < y and bbox[3] > y:
                 return [True, idx]
+        # Note: position may possibly be inside more than one bar/handle only the left-most (or right-most with reversed) can be moved
         return [False, None]
 
 

--- a/RangeSlider/RangeSlider.py
+++ b/RangeSlider/RangeSlider.py
@@ -313,18 +313,15 @@ class RangeSliderH(Frame):
             otherPos=positions[1]
             if self.cross_each_other == False:
                 if pos<=otherPos:
-                # if pos<otherPos:  # test pw
                     pos=pos
                 else:
                     pos=current_pos
-                    # self.selected_idx = otherIdx  # test pw, select the second handle 
             self.track[0], self.track[1], self.track[-1] = self.__addTrackL(self.slider_x, self.slider_y, self.canv_W-self.slider_x, self.slider_y, pos, otherPos)
         else:
             otherIdx=0
             otherPos=positions[0]
             if self.cross_each_other == False:
                 if pos>=otherPos:
-                # if pos>otherPos:  # test pw not allowing same values can sometimes be useful
                     pos=pos
                 else:
                     pos=current_pos

--- a/RangeSlider/RangeSlider.py
+++ b/RangeSlider/RangeSlider.py
@@ -130,7 +130,10 @@ class RangeSliderH(Frame):
         self.canv = Canvas(self, height = self.canv_H, width = self.canv_W, bg=bgColor, bd=0 , highlightthickness=0, relief='ridge')
         self.canv.pack()
         # now able to grab right handle with right click if two handles are on the same position
-        # other possibilities without right-click: move handle in direction of click on track; if bars have equal position on mousedown, select based on first movement 
+        # other possibilities without right-click: 
+        # - move handle in direction of click on track; 
+        # - if bars have equal position on mousedown, select based on first movement 
+        # - if bars are both at 0, select second/right handle
         self.canv.bind("<Button-1>", self._mouseMotion_b1)
         self.canv.bind("<Button-3>", self._mouseMotion_b3)
         self.canv.bind("<Motion>", self._mouseMotion_b1)  # still leave the selection on motion without click / after mouse was released


### PR DESCRIPTION
Hi,

First of all, thanks for this widget. I plan to use it to select a range of bytes from a file. 
I ran into an issue were with two sliders and `cross_each_other=False`, I could not select and move the right handle.
If both handles are moved to the zero/left-most position, that means that the slider handles can not be moved anymore.

 I introduced functionality to select the right-most handle with right click.

If `enable_right_click_movement=True` is given in init, right-click movement is set on.
Only implemented it for `RangeSliderH`, not `RangeSliderV`.

This may not be the best resolution for the issue I mentioned, but required less changes than other stuff I could think about.
Also, I left some comments in the code you may want to strip.
Other possibilities would be:
- When clicking on the track next to a handlebar, move handle in direction of the click on track; 
- if bars have equal position on mousedown, select the handle based on the first movement 
- if bars are both at 0, select second/right handle

Cheers!
