### PR TITLE
add trace / update on Sliders on external variable change

### DIFF
--- a/RangeSlider/RangeSlider.py
+++ b/RangeSlider/RangeSlider.py
@@ -88,6 +88,9 @@ class RangeSliderH(Frame):
         self.canv_W = self.W
         self.suffix=suffix
         self.variables=variables
+        if variables:
+            variables[0].trace_add("write", self._trace_vars_write)
+            variables[1].trace_add("write", self._trace_vars_write)
         self.step_marker = step_marker
         if self.step_marker:
             assert step_size > 0, "[step_size] must be provided if [step_marker] set to True."
@@ -348,6 +351,11 @@ class RangeSliderH(Frame):
             if bbox[0] < x and bbox[2] > x and bbox[1] < y and bbox[3] > y:
                 return [True, idx]
         return [False, None]
+    
+    def _trace_vars_write(self, *args):
+        firstVal = self.variables[0].get()
+        secondVal = self.variables[1].get()
+        self.forceValues([firstVal, secondVal])
 
 
 class RangeSliderV(Frame):
@@ -445,6 +453,9 @@ class RangeSliderV(Frame):
         self.canv_W = self.W
         self.suffix=suffix
         self.variables=variables
+        if variables:
+            variables[0].trace_add("write", self._trace_vars_write)
+            variables[1].trace_add("write", self._trace_vars_write)
         self.step_size= step_size / (self.max_val-self.min_val)
         if not show_value:
             self.slider_x = self.canv_W/2 # y pos of the slider
@@ -685,3 +696,8 @@ class RangeSliderV(Frame):
             if bbox[0] < x and bbox[2] > x and bbox[1] < y and bbox[3] > y:
                 return [True, idx]
         return [False, None]
+    
+    def _trace_vars_write(self, *args):
+        firstVal = self.variables[0].get()
+        secondVal = self.variables[1].get()
+        self.forceValues([firstVal, secondVal])

--- a/RangeSlider/RangeSlider.py
+++ b/RangeSlider/RangeSlider.py
@@ -89,8 +89,8 @@ class RangeSliderH(Frame):
         self.suffix=suffix
         self.variables=variables
         if variables:
-            variables[0].trace_add("write", self._trace_vars_write)
-            variables[1].trace_add("write", self._trace_vars_write)
+            variables[0].trace_add("write", self._trace_vars_write0)
+            variables[1].trace_add("write", self._trace_vars_write1)
         self.step_marker = step_marker
         if self.step_marker:
             assert step_size > 0, "[step_size] must be provided if [step_marker] set to True."
@@ -352,10 +352,13 @@ class RangeSliderH(Frame):
                 return [True, idx]
         return [False, None]
     
-    def _trace_vars_write(self, *args):
+    def _trace_vars_write0(self, *args):
         firstVal = self.variables[0].get()
+        self.__moveBar(0, (firstVal - self.min_val)/(self.max_val - self.min_val))
+
+    def _trace_vars_write1(self, *args):
         secondVal = self.variables[1].get()
-        self.forceValues([firstVal, secondVal])
+        self.__moveBar(1, (secondVal - self.min_val)/(self.max_val - self.min_val))
 
 
 class RangeSliderV(Frame):
@@ -454,8 +457,8 @@ class RangeSliderV(Frame):
         self.suffix=suffix
         self.variables=variables
         if variables:
-            variables[0].trace_add("write", self._trace_vars_write)
-            variables[1].trace_add("write", self._trace_vars_write)
+            variables[0].trace_add("write", self._trace_vars_write0)
+            variables[1].trace_add("write", self._trace_vars_write1)
         self.step_size= step_size / (self.max_val-self.min_val)
         if not show_value:
             self.slider_x = self.canv_W/2 # y pos of the slider
@@ -697,7 +700,10 @@ class RangeSliderV(Frame):
                 return [True, idx]
         return [False, None]
     
-    def _trace_vars_write(self, *args):
+    def _trace_vars_write0(self, *args):
         firstVal = self.variables[0].get()
+        self.__moveBar(0, (firstVal - self.min_val)/(self.max_val - self.min_val))
+
+    def _trace_vars_write1(self, *args):
         secondVal = self.variables[1].get()
-        self.forceValues([firstVal, secondVal])
+        self.__moveBar(1, (secondVal - self.min_val)/(self.max_val - self.min_val))


### PR DESCRIPTION
This one is pretty straightforward.

If the TkVar (I used IntVars) is changed from another widget, update the slider position.

This does _not_ enforce the not-crossing-each-other on manipulations made by other widgets.
I tried to include that but it would only work if I define the code outside the RangedSlider.

It can, however be nicely done on the variables with something like for both the variables.
```
def check_limit_var_left(*args):
      update_val = hLeft.get()
      if update_val>hRight.get():
          hLeft.set(min(update_val, hRight.get()))

hLeft.trace_add("write", check_limit_var_left)
```